### PR TITLE
bug fixed: setState after Notification is unmounted

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -83,6 +83,12 @@ class Notification extends Component {
             }
         }
     }
+    componentWillUnmount() {
+        if (this.dismissTimer) {
+            clearTimeout(this.dismissTimer);
+        }
+    }
+
     render() {
         const {
             type,


### PR DESCRIPTION
Hi, In some situation Notification component will call setState after it has been unmounted.
Please help to fix it, thanks!